### PR TITLE
Getter for name of CollisionDetectorAllocator

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -3,6 +3,7 @@
 API changes in MoveIt releases
 
 ## ROS Noetic
+- Static member variable interface of the CollisionDetectorAllocatorTemplate for the string NAME was replaced with a virtual method `getName`.
 - RobotModel no longer overrides empty URDF collision geometry by matching the visual geometry of the link.
 - Planned trajectories are *slow* by default.
   The default values of the `velocity_scaling_factor` and `acceleration_scaling_factor` can now be customized and default to 0.1 instead of 1.0.

--- a/moveit_core/collision_detection/include/moveit/collision_detection/allvalid/collision_detector_allocator_allvalid.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/allvalid/collision_detector_allocator_allvalid.h
@@ -39,16 +39,6 @@
 #include <moveit/collision_detection/collision_detector_allocator.h>
 #include <moveit/collision_detection/allvalid/collision_env_allvalid.h>
 
-#ifdef ROS_BUILD_SHARED_LIBS               // ros is being built around shared libraries
-#ifdef moveit_collision_detection_EXPORTS  // we are building a shared lib/dll
-#define MOVEIT_COLLISION_DETECTION_DECL ROS_HELPER_EXPORT
-#else  // we are using shared lib/dll
-#define MOVEIT_COLLISION_DETECTION_DECL ROS_HELPER_IMPORT
-#endif
-#else  // ros is being built around static libraries
-#define MOVEIT_COLLISION_DETECTION_DECL
-#endif
-
 namespace collision_detection
 {
 /** \brief An allocator for AllValid collision detectors */
@@ -56,6 +46,6 @@ class CollisionDetectorAllocatorAllValid
   : public CollisionDetectorAllocatorTemplate<CollisionEnvAllValid, CollisionDetectorAllocatorAllValid>
 {
 public:
-  MOVEIT_COLLISION_DETECTION_DECL static const std::string NAME;  // defined in collision_env_allvalid.cpp
+  const std::string& getName() const override;
 };
 }  // namespace collision_detection

--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_detector_allocator.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_detector_allocator.h
@@ -72,10 +72,7 @@ template <class CollisionEnvType, class CollisionDetectorAllocatorType>
 class CollisionDetectorAllocatorTemplate : public CollisionDetectorAllocator
 {
 public:
-  const std::string& getName() const override
-  {
-    return CollisionDetectorAllocatorType::NAME;
-  }
+  virtual const std::string& getName() const = 0;
 
   CollisionEnvPtr allocateEnv(const WorldPtr& world, const moveit::core::RobotModelConstPtr& robot_model) const override
   {

--- a/moveit_core/collision_detection/src/allvalid/collision_env_allvalid.cpp
+++ b/moveit_core/collision_detection/src/allvalid/collision_env_allvalid.cpp
@@ -37,99 +37,109 @@
 #include <moveit/collision_detection/allvalid/collision_env_allvalid.h>
 #include <moveit/collision_detection/allvalid/collision_detector_allocator_allvalid.h>
 
-const std::string collision_detection::CollisionDetectorAllocatorAllValid::NAME("ALL_VALID");
+namespace collision_detection
+{
+namespace
+{
+static const std::string NAME = "ALL_VALID";
+}  // namespace
 
-collision_detection::CollisionEnvAllValid::CollisionEnvAllValid(const moveit::core::RobotModelConstPtr& robot_model,
-                                                                double padding, double scale)
+CollisionEnvAllValid::CollisionEnvAllValid(const moveit::core::RobotModelConstPtr& robot_model, double padding,
+                                           double scale)
   : CollisionEnv(robot_model, padding, scale)
 {
 }
 
-collision_detection::CollisionEnvAllValid::CollisionEnvAllValid(const moveit::core::RobotModelConstPtr& robot_model,
-                                                                const WorldPtr& world, double padding, double scale)
+CollisionEnvAllValid::CollisionEnvAllValid(const moveit::core::RobotModelConstPtr& robot_model, const WorldPtr& world,
+                                           double padding, double scale)
   : CollisionEnv(robot_model, world, padding, scale)
 {
 }
 
-collision_detection::CollisionEnvAllValid::CollisionEnvAllValid(const CollisionEnv& other, const WorldPtr& world)
+CollisionEnvAllValid::CollisionEnvAllValid(const CollisionEnv& other, const WorldPtr& world)
   : CollisionEnv(other, world)
 {
 }
 
-void collision_detection::CollisionEnvAllValid::checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
-                                                                    const moveit::core::RobotState& state) const
+void CollisionEnvAllValid::checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
+                                               const moveit::core::RobotState& state) const
 {
   res.collision = false;
   if (req.verbose)
     ROS_INFO_NAMED("collision_detection", "Using AllValid collision detection. No collision checking is performed.");
 }
 
-void collision_detection::CollisionEnvAllValid::checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
-                                                                    const moveit::core::RobotState& state,
-                                                                    const AllowedCollisionMatrix& acm) const
+void CollisionEnvAllValid::checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
+                                               const moveit::core::RobotState& state,
+                                               const AllowedCollisionMatrix& acm) const
 {
   res.collision = false;
   if (req.verbose)
     ROS_INFO_NAMED("collision_detection", "Using AllValid collision detection. No collision checking is performed.");
 }
 
-void collision_detection::CollisionEnvAllValid::checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
-                                                                    const moveit::core::RobotState& state1,
-                                                                    const moveit::core::RobotState& state2) const
+void CollisionEnvAllValid::checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
+                                               const moveit::core::RobotState& state1,
+                                               const moveit::core::RobotState& state2) const
 {
   res.collision = false;
   if (req.verbose)
     ROS_INFO_NAMED("collision_detection", "Using AllValid collision detection. No collision checking is performed.");
 }
 
-void collision_detection::CollisionEnvAllValid::checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
-                                                                    const moveit::core::RobotState& state1,
-                                                                    const moveit::core::RobotState& state2,
-                                                                    const AllowedCollisionMatrix& acm) const
+void CollisionEnvAllValid::checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
+                                               const moveit::core::RobotState& state1,
+                                               const moveit::core::RobotState& state2,
+                                               const AllowedCollisionMatrix& acm) const
 {
   res.collision = false;
   if (req.verbose)
     ROS_INFO_NAMED("collision_detection", "Using AllValid collision detection. No collision checking is performed.");
 }
 
-void collision_detection::CollisionEnvAllValid::distanceRobot(const collision_detection::DistanceRequest& req,
-                                                              collision_detection::DistanceResult& res,
-                                                              const moveit::core::RobotState& state) const
+void CollisionEnvAllValid::distanceRobot(const DistanceRequest& req, DistanceResult& res,
+                                         const moveit::core::RobotState& state) const
 {
   res.collision = false;
 }
 
-double collision_detection::CollisionEnvAllValid::distanceRobot(const moveit::core::RobotState& state) const
+double CollisionEnvAllValid::distanceRobot(const moveit::core::RobotState& state) const
 {
   return 0.0;
 }
 
-double collision_detection::CollisionEnvAllValid::distanceRobot(const moveit::core::RobotState& state,
-                                                                const AllowedCollisionMatrix& acm) const
+double CollisionEnvAllValid::distanceRobot(const moveit::core::RobotState& state,
+                                           const AllowedCollisionMatrix& acm) const
 {
   return 0.0;
 }
 
-void collision_detection::CollisionEnvAllValid::checkSelfCollision(const CollisionRequest& req, CollisionResult& res,
-                                                                   const moveit::core::RobotState& state) const
+void CollisionEnvAllValid::checkSelfCollision(const CollisionRequest& req, CollisionResult& res,
+                                              const moveit::core::RobotState& state) const
 {
   res.collision = false;
   if (req.verbose)
     ROS_INFO_NAMED("collision_detection", "Using AllValid collision detection. No collision checking is performed.");
 }
 
-void collision_detection::CollisionEnvAllValid::checkSelfCollision(const CollisionRequest& req, CollisionResult& res,
-                                                                   const moveit::core::RobotState& state,
-                                                                   const AllowedCollisionMatrix& acm) const
+void CollisionEnvAllValid::checkSelfCollision(const CollisionRequest& req, CollisionResult& res,
+                                              const moveit::core::RobotState& state,
+                                              const AllowedCollisionMatrix& acm) const
 {
   res.collision = false;
   if (req.verbose)
     ROS_INFO_NAMED("collision_detection", "Using AllValid collision detection. No collision checking is performed.");
 }
 
-void collision_detection::CollisionEnvAllValid::distanceSelf(const collision_detection::DistanceRequest& req,
-                                                             collision_detection::DistanceResult& res,
-                                                             const moveit::core::RobotState& state) const
+void CollisionEnvAllValid::distanceSelf(const DistanceRequest& req, DistanceResult& res,
+                                        const moveit::core::RobotState& state) const
 {
   res.collision = false;
 }
+
+const std::string& CollisionDetectorAllocatorAllValid::getName() const
+{
+  return NAME;
+}
+
+}  // namespace collision_detection

--- a/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/collision_detector_allocator_bullet.h
+++ b/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/collision_detector_allocator_bullet.h
@@ -46,6 +46,6 @@ class CollisionDetectorAllocatorBullet
   : public CollisionDetectorAllocatorTemplate<CollisionEnvBullet, CollisionDetectorAllocatorBullet>
 {
 public:
-  static const std::string NAME;  // defined in collision_env_bullet.cpp
+  const std::string& getName() const override;
 };
 }  // namespace collision_detection

--- a/moveit_core/collision_detection_bullet/src/collision_env_bullet.cpp
+++ b/moveit_core/collision_detection_bullet/src/collision_env_bullet.cpp
@@ -43,9 +43,12 @@
 
 namespace collision_detection
 {
-const std::string CollisionDetectorAllocatorBullet::NAME("Bullet");
+namespace
+{
+static const std::string NAME = "Bullet";
 const double MAX_DISTANCE_MARGIN = 99;
 constexpr char LOGNAME[] = "collision_detection.bullet";
+}  // namespace
 
 CollisionEnvBullet::CollisionEnvBullet(const moveit::core::RobotModelConstPtr& model, double padding, double scale)
   : CollisionEnv(model, padding, scale)
@@ -436,4 +439,9 @@ void CollisionEnvBullet::addLinkAsCollisionObject(const urdf::LinkSharedPtr& lin
   }
 }
 
-}  // end of namespace collision_detection
+const std::string& CollisionDetectorAllocatorBullet::getName() const
+{
+  return NAME;
+}
+
+}  // namespace collision_detection

--- a/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_detector_allocator_fcl.h
+++ b/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_detector_allocator_fcl.h
@@ -39,18 +39,6 @@
 #include <moveit/collision_detection/collision_detector_allocator.h>
 #include <moveit/collision_detection_fcl/collision_env_fcl.h>
 
-// Import/export for windows dll's and visibility for gcc shared libraries.
-
-#ifdef ROS_BUILD_SHARED_LIBS                   // ros is being built around shared libraries
-#ifdef moveit_collision_detection_fcl_EXPORTS  // we are building a shared lib/dll
-#define MOVEIT_COLLISION_DETECTION_FCL_DECL ROS_HELPER_EXPORT
-#else  // we are using shared lib/dll
-#define MOVEIT_COLLISION_DETECTION_FCL_DECL ROS_HELPER_IMPORT
-#endif
-#else  // ros is being built around static libraries
-#define MOVEIT_COLLISION_DETECTION_FCL_DECL
-#endif
-
 namespace collision_detection
 {
 /** \brief An allocator for FCL collision detectors */
@@ -58,6 +46,6 @@ class CollisionDetectorAllocatorFCL
   : public CollisionDetectorAllocatorTemplate<CollisionEnvFCL, CollisionDetectorAllocatorFCL>
 {
 public:
-  MOVEIT_COLLISION_DETECTION_FCL_DECL static const std::string NAME;  // defined in collision_env_fcl.cpp
+  const std::string& getName() const override;
 };
 }  // namespace collision_detection

--- a/moveit_core/collision_detection_fcl/src/collision_env_fcl.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_env_fcl.cpp
@@ -46,8 +46,12 @@
 
 namespace collision_detection
 {
-const std::string CollisionDetectorAllocatorFCL::NAME("FCL");
+namespace
+{
+static const std::string NAME = "FCL";
 constexpr char LOGNAME[] = "collision_detection.fcl";
+
+}  // namespace
 
 CollisionEnvFCL::CollisionEnvFCL(const moveit::core::RobotModelConstPtr& model, double padding, double scale)
   : CollisionEnv(model, padding, scale)
@@ -432,4 +436,9 @@ void CollisionEnvFCL::updatedPaddingOrScaling(const std::vector<std::string>& li
   }
 }
 
-}  // end of namespace collision_detection
+const std::string& CollisionDetectorAllocatorFCL::getName() const
+{
+  return NAME;
+}
+
+}  // namespace collision_detection

--- a/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_detector_allocator_distance_field.h
+++ b/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_detector_allocator_distance_field.h
@@ -46,6 +46,6 @@ class CollisionDetectorAllocatorDistanceField
   : public CollisionDetectorAllocatorTemplate<CollisionEnvDistanceField, CollisionDetectorAllocatorDistanceField>
 {
 public:
-  static const std::string NAME;  // defined in collision_env_distance_field.cpp
+  const std::string& getName() const override;
 };
 }  // namespace collision_detection

--- a/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_detector_allocator_hybrid.h
+++ b/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_detector_allocator_hybrid.h
@@ -39,16 +39,6 @@
 #include <moveit/collision_detection/collision_detector_allocator.h>
 #include <moveit/collision_distance_field/collision_env_hybrid.h>
 
-#ifdef ROS_BUILD_SHARED_LIBS                    // ros is being built around shared libraries
-#ifdef moveit_collision_distance_field_EXPORTS  // we are building a shared lib/dll
-#define MOVEIT_COLLISION_DISTANCE_FIELD_DECL ROS_HELPER_EXPORT
-#else  // we are using shared lib/dll
-#define MOVEIT_COLLISION_DISTANCE_FIELD_DECL ROS_HELPER_IMPORT
-#endif
-#else  // ros is being built around static libraries
-#define MOVEIT_COLLISION_DISTANCE_FIELD_DECL
-#endif
-
 namespace collision_detection
 {
 /** \brief An allocator for Hybrid collision detectors */
@@ -56,6 +46,6 @@ class CollisionDetectorAllocatorHybrid
   : public CollisionDetectorAllocatorTemplate<CollisionEnvHybrid, CollisionDetectorAllocatorHybrid>
 {
 public:
-  MOVEIT_COLLISION_DISTANCE_FIELD_DECL static const std::string NAME;  // defined in collision_env_hybrid.cpp
+  const std::string& getName() const override;
 };
 }  // namespace collision_detection

--- a/moveit_core/collision_distance_field/src/collision_env_distance_field.cpp
+++ b/moveit_core/collision_distance_field/src/collision_env_distance_field.cpp
@@ -48,9 +48,11 @@
 
 namespace collision_detection
 {
+namespace
+{
+static const std::string NAME = "DISTANCE_FIELD";
 const double EPSILON = 0.001f;
-
-const std::string collision_detection::CollisionDetectorAllocatorDistanceField::NAME("DISTANCE_FIELD");
+}  // namespace
 
 CollisionEnvDistanceField::CollisionEnvDistanceField(
     const moveit::core::RobotModelConstPtr& robot_model,
@@ -1803,4 +1805,10 @@ CollisionEnvDistanceField::generateDistanceFieldCacheEntryWorld()
   dfce->distance_field_->addPointsToField(add_points);
   return dfce;
 }
+
+const std::string& CollisionDetectorAllocatorDistanceField::getName() const
+{
+  return NAME;
+}
+
 }  // namespace collision_detection

--- a/moveit_core/collision_distance_field/src/collision_env_hybrid.cpp
+++ b/moveit_core/collision_distance_field/src/collision_env_hybrid.cpp
@@ -39,7 +39,10 @@
 
 namespace collision_detection
 {
-const std::string collision_detection::CollisionDetectorAllocatorHybrid::NAME("HYBRID");
+namespace
+{
+static const std::string NAME = "HYBRID";
+}  // namespace
 
 CollisionEnvHybrid::CollisionEnvHybrid(
     const moveit::core::RobotModelConstPtr& robot_model,
@@ -181,4 +184,10 @@ void CollisionEnvHybrid::getAllCollisions(const CollisionRequest& req, Collision
 {
   cenv_distance_->getAllCollisions(req, res, state, acm, gsr);
 }
+
+const std::string& CollisionDetectorAllocatorHybrid::getName() const
+{
+  return NAME;
+}
+
 }  // namespace collision_detection


### PR DESCRIPTION
### Description

Here is the PR to change the interface for the CollisionDetectorAllocator objects to have a simple getter method for the name.  Please test this to see if it works for you.